### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/config/src/main/java/org/atteo/config/XmlUtils.java
+++ b/config/src/main/java/org/atteo/config/XmlUtils.java
@@ -27,6 +27,9 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Node;
 
 public class XmlUtils {
+	private XmlUtils() {
+	}
+
 	public static String prettyPrint(Node node) {
 		try {
 			Transformer transformer = TransformerFactory.newInstance().newTransformer();

--- a/container/src/main/java/org/atteo/moonshine/services/internal/GuiceBindingsHelper.java
+++ b/container/src/main/java/org/atteo/moonshine/services/internal/GuiceBindingsHelper.java
@@ -29,6 +29,9 @@ import com.google.inject.spi.PrivateElements;
 
 public class GuiceBindingsHelper {
 
+	private GuiceBindingsHelper() {
+	}
+
 	public static void printServiceElements(List<? extends ServiceInfo> infos) {
 		for (ServiceInfo info : infos) {
 

--- a/container/src/main/java/org/atteo/moonshine/services/internal/ReflectionTools.java
+++ b/container/src/main/java/org/atteo/moonshine/services/internal/ReflectionTools.java
@@ -19,6 +19,9 @@ import javax.inject.Singleton;
 
 
 public class ReflectionTools {
+	private ReflectionTools() {
+	}
+
 	/**
 	 * Checks whether class is marked as singleton.
 	 */

--- a/container/src/main/java/org/atteo/moonshine/services/internal/ServiceModuleRewriter.java
+++ b/container/src/main/java/org/atteo/moonshine/services/internal/ServiceModuleRewriter.java
@@ -35,6 +35,9 @@ import com.google.inject.spi.InjectionRequest;
 import com.google.inject.spi.PrivateElements;
 
 public class ServiceModuleRewriter {
+	private ServiceModuleRewriter() {
+	}
+
 	/**
 	 * Annotate exposed bindings with Names.named(service.getId()).
 	 * Additionally request injection of service object.

--- a/reflection-utils/src/main/java/org/atteo/moonshine/reflection/ReflectionUtils.java
+++ b/reflection-utils/src/main/java/org/atteo/moonshine/reflection/ReflectionUtils.java
@@ -22,6 +22,9 @@ import java.util.LinkedList;
 
 
 public class ReflectionUtils {
+	private ReflectionUtils() {
+	}
+
 	/**
 	 * Return all ancestors of a given class.
 	 *

--- a/services/jmx/src/main/java/org/atteo/moonshine/jmx/JmxUtils.java
+++ b/services/jmx/src/main/java/org/atteo/moonshine/jmx/JmxUtils.java
@@ -30,6 +30,9 @@ import com.sun.tools.attach.VirtualMachine;
 
 public class JmxUtils {
 
+	private JmxUtils() {
+	}
+
 	public static long getVirtualMachinePid() {
 		String name = ManagementFactory.getRuntimeMXBean().getName();
 		return Long.parseLong(name.substring(0, name.indexOf('@')));

--- a/services/jta/src/main/java/org/atteo/moonshine/jta/Transaction.java
+++ b/services/jta/src/main/java/org/atteo/moonshine/jta/Transaction.java
@@ -28,6 +28,9 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 public class Transaction {
+	private Transaction() {
+	}
+
 	public static interface Runnable {
 		void run();
 	}

--- a/services/webserver/src/main/java/org/atteo/moonshine/webserver/crypto/Crypto.java
+++ b/services/webserver/src/main/java/org/atteo/moonshine/webserver/crypto/Crypto.java
@@ -52,8 +52,11 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 public class Crypto {
+	private Crypto() {
+	}
+
 	public static void createSelfSignedCertificate(File keystore, String alias,
-			String keystorePassword) {
+												   String keystorePassword) {
 		try {
 			Provider bouncyCastleProvider = new BouncyCastleProvider();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.